### PR TITLE
Use boot's -x option to exclude transitive org.clojure/clojure version dependency

### DIFF
--- a/autoload/jack_in.vim
+++ b/autoload/jack_in.vim
@@ -9,7 +9,7 @@ function! s:RunRepl(cmd)
 endfunction
 
 function! jack_in#boot(...)
-  let l:boot_string = 'boot -i "(require ''cider.tasks)"'
+  let l:boot_string = 'boot -x -i "(require ''cider.tasks)"'
   for [dep, inj] in items(g:jack_in_injections)
     let l:boot_string .= printf(' -d %s:%s', dep, inj['version'])
   endfor


### PR DESCRIPTION
refactor-nrepl has numerous dependencies which, themselves, have transitive dependencies on specific versions of Clojure. This results in Boot giving warnings like:

```
Classpath conflict: org.clojure/clojure version 1.8.0 already loaded, NOT loading
version 1.4.0
```

when you start a REPL with refactor-nrepl injected, like we're doing here.

I saw that Boot has this option:

```
-x --exclude-clojure        Add org.clojure/clojure to the set of global exclusions.
```

I think this is exactly what we want to do. We don't want our middleware's dependencies' transitive dependencies on specific Clojure versions to interfere with the Clojure project we're actually working on.

In practice, I don't think it hurts anything to allow these transitive dependencies, because Boot is clearly NOT loading another version of Clojure after it's already been loaded, but I think it would be nice to use this flag so that we can avoid the warning appearing in the REPL every time.

NB: I tested this change locally and can confirm the warnings go away.