### PR TITLE
Updating repl cmdline

### DIFF
--- a/autoload/jack_in.vim
+++ b/autoload/jack_in.vim
@@ -66,18 +66,23 @@ endfunction
 
 function! jack_in#clj_cmd(...)
   let l:clj_string = 'clj'
-  let l:deps_map = '{:deps {nrepl/nrepl {:mvn/version "0.7.0"} '
-  let l:cider_opts = '-e "(require ''nrepl.cmdline) (nrepl.cmdline/-main \"--middleware\" \"['
+  let l:main_fn = '-m nrepl.cmdline'
+  let l:interactive = '--interactive'
+
+  let l:deps = '-Sdeps ''{:deps {nrepl/nrepl {:mvn/version "0.7.0"} '
+  let l:cider_opts = '--middleware ''['
 
   for [dep, inj] in items(g:jack_in_injections)
-    let l:deps_map .= dep . ' {:mvn/version "' . inj['version'] . '"} '
-    let l:cider_opts .= ' '.inj['middleware']
+    let l:deps .= dep . ' {:mvn/version "' . inj['version'] . '"} '
+    let l:cider_opts .= ' "'.inj['middleware'] . '"'
   endfor
 
-  let l:deps_map .= '}}'
-  let l:cider_opts .= ']\")"'
+  let l:deps .= '}}'''
+  let l:cider_opts .= ']'''
 
-  return l:clj_string . ' -Sdeps ''' . l:deps_map . ''' ' . join(a:000, ' ') . ' ' . l:cider_opts . ' '
+  let l:cmd = l:clj_string . ' ' . l:deps . ' ' . l:main_fn . ' ' . l:cider_opts . ' ' . l:interactive
+
+  return l:cmd
 endfunction
 
 function! jack_in#clj(is_bg, ...)


### PR DESCRIPTION
This updates the repl command line to the most recent recommended form, which gets rid of warnings.  It also makes the repl interactive by default so that you can both connect to it with Conjure as well as interact with it.