### PR TITLE
Add -M option to clj_cmd

### DIFF
--- a/autoload/jack_in.vim
+++ b/autoload/jack_in.vim
@@ -65,7 +65,7 @@ function! jack_in#lein(is_bg, ...)
 endfunction
 
 function! jack_in#clj_cmd(...)
-  let l:clj_string = 'clj'
+  let l:clj_string = 'clj -M'
   let l:deps_map = '{:deps {nrepl/nrepl {:mvn/version "0.9.0"} '
   let l:cider_opts = '-e "(require ''nrepl.cmdline) (nrepl.cmdline/-main \"--middleware\" \"['
 


### PR DESCRIPTION
Suppresses warning that implicit use of clojure.main with options is deprecated